### PR TITLE
Use npm command from package.json

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ http.cors.allow-credentials: true
 2. git checkout master
 3. npm install
 4. bower install
-5. gulp watch (runs dejavu on http://localhost:1358)
+5. npm start (runs dejavu on http://localhost:1358)
 
 #### Local Build
 


### PR DESCRIPTION
- This takes the package locally installed gulp.
Running `gulp watch` from the command line requires gulp to be
installed at a global level.