### PR TITLE
Typo in Elasticsearch config for Chrome extension

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ For example: If you are using the chrome-extension instead of docker image, the 
 
 ```sh
 http.port: 9200
-http.cors.allow-origin: "chrome-extension://jopjeaiilkcibeohjdmejhoifenbnmlh/"
+http.cors.allow-origin: "chrome-extension://jopjeaiilkcibeohjdmejhoifenbnmlh"
 http.cors.enabled: true
 http.cors.allow-headers : X-Requested-With,X-Auth-Token,Content-Type,Content-Length,Authorization
 http.cors.allow-credentials: true


### PR DESCRIPTION
Had to remove the trailing slash from `http.cors.allow-origin` (matching the config submitted by @MrOrz over in https://github.com/appbaseio/dejavu/issues/48) in order for the Chrome extension to work.