### PR TITLE
Add a CONTRIBUTING.md File. 

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,55 @@
+# Contributing to Dejavu
+
+:+1::tada: First off, thanks for taking the time to contribute! :tada::+1:
+
+
+1. Fork repo
+2. Create a branch for the issue you are working on from one of the branches listed below depending on what you are intending to contribute to. 
+3. Submit a Pull Request against whichever branch applies. 
+
+
+#### Branches
+
+`dev` branch is the bleeding edge version of dejavu, all new changes go here.
+
+`chrome-extension` branch is where we make chrome extension related changes.
+
+`gh-pages` branch is for the hosted app, as well as for the version that runs on https://dashboard.appbase.io.
+
+
+#### Local Installation
+
+1. `git clone` your fork of https://github.com/appbaseio/dejavu
+2. `git checkout dev`
+3. `npm install`
+4. `bower install`
+5. `npm start` (open dejavu in the browser on http://localhost:1358/live)
+
+#### Generating an AppName and Url.
+
+1. Create an account here: https://dashboard.appbase.io
+2. Follow instructions to create an appname. 
+3. Click through to newly created app
+4. Click on the Credentials tab. 
+5. Copy Read-only or Admin API Key
+6. Url is `https://${API_KEY}@scalr.api.appbase.io`
+
+#### Local Build
+
+#### `dev` branch: Webpage
+
+```sh
+$ npm start
+```
+
+#### `chrome-extension` branch: Chrome extension
+
+```sh
+$ npm run build_chrome_extension
+```
+
+#### `gh-pages` branch: Github hosted pages
+
+```sh
+$ npm run build_gh_pages
+```

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ dejavu: The Missing Web UI for Elasticsearch
   d. [Importing JSON or CSV Data](#importing-json-or-csv-data)  
 3. **[Comparison](#3-comparison-with-other-data-browsers)**
 4. **[Roadmap](#4-roadmap)**
-5. **[Build Locally](#5-build-locally)**  
+5. **[Build Locally / Contributing](#5-build-locally)**  
 6. **[Get Dejavu](#6-get-dejavu)**  
   a. [Docker Installation](#docker-installation)  
   b. [Hosted Alternatives](#hosted-alternatives)
@@ -103,38 +103,7 @@ Roadmap for version `2.0.0` release, subject to change:
 
 ### 5. Build Locally
 
-`dev` branch is the bleeding edge version of dejavu, all new changes go here.
-
-`chrome-extension` branch is where we make chrome extension related changes.
-
-`gh-pages` branch is for the hosted app, as well as for the version that runs on https://dashboard.appbase.io.
-
-
-#### Local Installation
-
-1. git clone https://github.com/appbaseio/dejavu
-2. git checkout dev
-3. npm install
-4. bower install
-5. npm start (open dejavu in the browser on http://localhost:1358/live)
-
-#### Local Build
-
-#### `chrome-extension` branch: Chrome extension
-
-```sh
-$ npm run build_chrome_extension
-```
-
-#### `gh-pages` branch: Github hosted pages
-
-```sh
-$ npm run build_gh_pages
-```
-
-#### How to Contribute
-
-The source code is under the ``live/src`` directory. You can make pull requests against the ``dev`` branch.
+See the **[CONTRIBUTING File](https://raw.githubusercontent.com/appbaseio/dejavu/dev/CONTRIBUTING.md)**
 
 ---
 


### PR DESCRIPTION
Hey,

As I was jumping on #124 I found the setup took a few minutes because the **Build Locally** section of the readme was missing info on how to get an AppName and Url so this PR adds some info. 

While I was updating that I thought it was best to follow the standard oss pattern and have a `CONTRIBUTING.md` file. So I've moved the entire Build Locally section of the readme to the contributing file and linked it in the readme as well. 

Feel free to keep it as is if you'd like however I do think the Generating AppName and Url portion should be added either way. 