### PR TITLE
Add error state check to sCU, to ensure re-render

### DIFF
--- a/live/src/js/table/Cell.js
+++ b/live/src/js/table/Cell.js
@@ -110,7 +110,8 @@ class Cell extends React.Component {
 			this.state.data !== nextState.data ||
 			this.props.datatype.type === 'geo_point' ||
 			this.props.loadImages !== nextProps.loadImages ||
-			this.state.imageLoadError !== nextState.imageLoadError
+			this.state.imageLoadError !== nextState.imageLoadError ||
+			this.state.showError !== nextState.showError
 		) {
 			return true;
 		}


### PR DESCRIPTION
So the issue here was related to the `cell.js`'s `shouldComponentUpdate` function not including a check of the error state. The error state was being set but the dialog would only render if one of the other conditions were met. Then the close action cleared the error state and the same issue where the dialog would never disappear unless one of the other conditions were met. 

This pr addresses this issue, __however__ I would strongly recommend that this entire function be removed. It's commonly discussed in the community that `shouldComponentUpdate` introduces more issues than it solves. Given that this is a cell (small ui component) there is little harm in a re-render. Seeing how it triggers error state change and other functionality it's probably ideal to not prevent it through a `shouldComponentUpdate`. 

If you would like me to remove it instead I can do that in this PR. 

I've also added issue #127 purposing that we disable the editing action all together that way this error would have been prevented much earlier. It will provide a much better user experience to know that editing is unavailable rather then working on the assumption it is and receiving a un authorized error. 

This PR will complete #124 