### PR TITLE
Fixes Dropdown UI not going away after selecting a value

### DIFF
--- a/live/src/js/table/FilterDropdown.js
+++ b/live/src/js/table/FilterDropdown.js
@@ -31,8 +31,10 @@ class FilterDropdown extends React.Component {
 	};
 
 	applyFilter = () => {
-		if (this.state.filterField != null && this.state.filterValue != null && this.state.filterValue != '')
+		if (this.state.filterField != null && this.state.filterValue != null && this.state.filterValue != '') {
 			this.props.filterInfo.applyFilter(this.props.type, this.props.columnField, this.state.filterField, this.state.filterValue, this.props.analyzed);
+			document.body.click();
+		}
 	};
 
 	render() {


### PR DESCRIPTION
Fixes #174, by implementing what @divyanshu013 suggested which is adding `document.body.click()` after the filter has been applied. 

## Example 
![dejavufix](https://user-images.githubusercontent.com/27080760/37988966-2e499174-31d0-11e8-9314-0f21eb3c9a78.gif)
