### PR TITLE
Fixes Export UI modal closing with clicking outside

### DIFF
--- a/live/src/js/features/ExportasJson.js
+++ b/live/src/js/features/ExportasJson.js
@@ -5,20 +5,29 @@ import { Modal, Button } from 'react-bootstrap';
 
 class ImportData extends React.Component {
 	state = {
-		showModal: false
+		showModal: false,
+		exportClose: false
 	};
 
 	componentDidUpdate() {}
 
 	close = () => {
-		this.setState({
-			showModal: false
+		var thisRef = this;
+		$(".modal-content").click(function(e) {
+			thisRef.state.exportClose = true;
 		});
+		
+		if(this.state.exportClose) {
+		 	this.setState({
+				showModal: false
+			});
+		}
 	};
 
 	open = () => {
 		this.setState({
-			showModal: true
+			showModal: true,
+			exportClose: false
 		}, () => {
 			$('.modal-text').hide();
 		});

--- a/live/src/js/features/ExportasJson.js
+++ b/live/src/js/features/ExportasJson.js
@@ -13,7 +13,7 @@ class ImportData extends React.Component {
 
 	close = () => {
 		var thisRef = this;
-		$(".modal-content").click(function(e) {
+		$(".close").click(function(e) {
 			thisRef.state.exportClose = true;
 		});
 		


### PR DESCRIPTION
Fixes #176 by adding an `exportClose` state to the ImportData class in `ExportasJson.js`. This state in combination with checking if the user has clicked the close button allows us to only close the export UI if the close button is pressed.

## Example
![dejavuexportfix](https://user-images.githubusercontent.com/27080760/38122196-94e4aacc-33a1-11e8-9c64-41e23ddafbd1.gif)

