### PR TITLE
Adds Calendar Widget For Date Filter

### DIFF
--- a/live/src/js/table/SingleMenuItem.js
+++ b/live/src/js/table/SingleMenuItem.js
@@ -1,11 +1,14 @@
 var React = require('react');
+var DateTime = require('react-datetime');
+var dateFormat = require('dateformat');
 import { OverlayTrigger, Tooltip } from 'react-bootstrap';
 
 //Radio button with appropriate search input field
 class SingleMenuItem extends React.Component {
 	state = {
 		filterField: '',
-		filterValue: ''
+		filterValue: '',
+		dateStore: ''
 	};
 
 	changeFilter = (e) => {
@@ -45,6 +48,65 @@ class SingleMenuItem extends React.Component {
 		}
 	};
 
+	setDate = (dateData) => { 
+		var date = new Date(dateData);
+		var formattedDate = null;
+		try {	
+			formattedDate = dateFormat(date,"yyyy-mm-dd");
+		}
+		catch(err) {
+			console.log("Date format error: " + err);
+		} 
+		this.setState({
+			filterValue: formattedDate
+		});
+		this.props.getFilterVal(formattedDate);	
+	}
+
+	setRangeStart = (dateData) => { 
+		var date = new Date(dateData);
+		var formattedDate = null;
+		try {	
+			formattedDate = dateFormat(date,"yyyy-mm-dd");
+		}
+		catch(err) {
+			console.log("Date format error: " + err);
+		} 
+		if(this.state.dateStore != '' && this.state.dateStore !=null) {
+			var filterValue = this.state.dateStore+'@'+ formattedDate;
+			this.setState({
+				dateStore: filterValue
+			});
+			this.props.getFilterVal(filterValue);
+		} else {
+			this.setState({
+				dateStore: formattedDate
+			});
+		}
+	}
+
+	setRangeEnd = (dateData) => { 
+		var date = new Date(dateData);
+		var formattedDate = null;
+		try {	
+			var formattedDate = dateFormat(date,"yyyy-mm-dd");
+		}
+		catch(err) {
+			console.log("Date format error: " + err);
+		} 
+		if(this.state.dateStore != '' && this.state.dateStore !=null) {
+			var filterValue = this.state.dateStore+'@'+ formattedDate;
+			this.setState({
+				dateStore: filterValue
+			});
+			this.props.getFilterVal(filterValue);
+		} else {
+			this.setState({
+				dateStore: formattedDate
+			});
+		}	
+	}
+
 	render() {
 		let tooltip = null;
 		const { val, datatype } = this.props;
@@ -66,22 +128,22 @@ class SingleMenuItem extends React.Component {
 		var key = filterKeyGen(this.props.columnField, this.props.val);
 		var keyInput = key + '-input';
 		var keyInputRange = key + '-inputRange';
-		var searchElement = (<div className="searchElement">
-								<input id={keyInput} className="form-control" type="text" placeholder={placeholder} onKeyUp={this.valChange} />
+		var searchElement = null;
+
+		if(datatype === 'date') {	
+			searchElement = (<div className="searchElement"  >
+								<DateTime dateFormat='YYYY-MM-DD' closeOnSelect= {true} onBlur={this.setDate}  timeFormat= {false} inputProps={{ placeholder: 'select date', id: keyInput, className: 'form-control', onKeyUp:this.valChange }} />
+							</div>);					
+		} else {
+			searchElement = (<div className="searchElement">
+								<input id={keyInput} className="form-control" type="text" placeholder="gottem" onKeyUp={this.valChange} />
 							</div>);
+		}
 
 		if(this.props.val == 'range') {
-			searchElement = (<div className="searchElement">
-								<input id={keyInput}
-									className="form-control"
-									type="text"
-									placeholder="starting date"
-									onKeyUp={this.rangeChange.bind(null, key)} />
-								<input id={keyInputRange}
-									className="form-control mt-5"
-									type="text"
-									placeholder="ending date"
-									onKeyUp={this.rangeChange.bind(null, key)} />
+			searchElement = (<div className="searchElement">					
+							 	<DateTime dateFormat='YYYY-MM-DD' closeOnSelect= {true} timeFormat= {false} onBlur={this.setRangeStart}  inputProps={{ placeholder: 'starting date', id: keyInput, className: 'form-control', onKeyUp:this.rangeChange.bind(null, key) }} />
+								<DateTime dateFormat='YYYY-MM-DD'  closeOnSelect= {true} timeFormat= {false} onBlur={this.setRangeEnd}  inputProps={{ placeholder: 'ending date', id: keyInputRange, className: 'form-control mt-5', onKeyUp:this.rangeChange.bind(null, key) }} />
 							</div>)
 		} else if(this.props.val == 'true' || this.props.val == 'false' ) {
 			searchElement = <span></span>;


### PR DESCRIPTION
Adds feature from issue #181 by adding a [react-datetime](https://github.com/YouCanBookMe/react-datetime) calendar widget to the date filters. Usage is pretty straightforward, the widget will open when the user selects either **greater than**, **less than**, or **range** radio buttons. 

## Summary
One thing to note is I needed to add three additional functions to `SingleMenuItem.js` because the `<Datetime/>` tag handles events different than a regular input [API reference](https://github.com/YouCanBookMe/react-datetime#api) and returns date data in milliseconds (UNIX time) depending on the event which in this case is `onBlur`. 

So once onBlur is triggered we attempt to parse the date and set the `filterValue` accordingly. This logic happens in `setDate`. For range values it is set a bit differently. I created two functions called `setRangeStart` and `setRangeEnd` which handle this use case. Depending on which one is set first (starting date or ending date) the function will either store the date in the `dateStore` state to be used by the contrasting function that will set the dates as the date range for `filterValue`.   


## Example
![reactdatetime](https://user-images.githubusercontent.com/27080760/38906283-b5c8f158-4283-11e8-8f44-8d7d593a2ee0.gif)


***Feedback is welcome!***