### PR TITLE
The must clause was changed to should clause.

### DIFF
--- a/live/src/js/helper/feed.js
+++ b/live/src/js/helper/feed.js
@@ -853,7 +853,7 @@ var feed = (function() {
 				var boolQuery = {
 					'minimum_should_match': 1
 				}
-				var boolType = method === 'has' ? 'must' : 'must_not';
+				var boolType = method === 'has' ? 'should' : 'must_not';
 				boolQuery[boolType] = queryMaker;
 				return {
 					'bool': boolQuery


### PR DESCRIPTION
The filter of `has` seems to be not functionning properly due to the change of `minimum_should_match`. If the `minimum_should_match` is greater than the number of should clauses, the bool query will return no result. Therefore, the must clause was changed to should clause. [The Related Pull Request](https://github.com/elastic/elasticsearch/pull/15571)
