### PR TITLE
Add new date format, url encode document id

### DIFF
--- a/app/src/apis/cell.js
+++ b/app/src/apis/cell.js
@@ -15,15 +15,19 @@ const setCellValue = async (app, type, rawUrl, id, property, value) => {
 		const headers = getHeaders(rawUrl);
 		const customHeaders = getCustomHeaders(app);
 		const doc = unflatten({ [property]: value });
+		const formattedId = encodeURIComponent(id);
 
-		const res = await fetch(`${url}/${app}/${type}/${id}/_update`, {
-			headers: {
-				...headers,
-				...convertArrayToHeaders(customHeaders),
+		const res = await fetch(
+			`${url}/${app}/${type}/${formattedId}/_update`,
+			{
+				headers: {
+					...headers,
+					...convertArrayToHeaders(customHeaders),
+				},
+				method: 'POST',
+				body: JSON.stringify({ doc }),
 			},
-			method: 'POST',
-			body: JSON.stringify({ doc }),
-		}).then(response => response.json());
+		).then(response => response.json());
 
 		if (res.status >= 400) {
 			throw new CustomError(

--- a/app/src/utils/date.js
+++ b/app/src/utils/date.js
@@ -12,6 +12,8 @@ const dateFormatMap = {
 	basic_time: 'HHmmss.SSSZ',
 	basic_time_no_millis: 'HHmmssZ',
 	strict_date_optional_time: 'YYYYMMDD',
+	date_hour_minute_second: 'YYYY-MM-DDTHH:mm:ss',
+	strict_date_hour_minute_second: 'YYYY-MM-DDTHH:mm:ss',
 };
 
 const getDateFormat = format => {


### PR DESCRIPTION
I add a pair of date formats to the date parsing. 

When editing an object, url encode the object id, which helps if your object id contains url special characters.