### PR TITLE
Run the Dejavu container as non-root user

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,13 +2,19 @@ FROM node:11.3.0-alpine
 MAINTAINER appbase.io <info@appbase.io>
 
 WORKDIR /dejavu
+
 ADD package.json yarn.lock /dejavu/
 
-RUN apk --no-cache update && apk --no-cache add git && rm -rf /var/cache/apk/*
+RUN apk --no-cache update \
+    && apk --no-cache add git \
+    && rm -rf /var/cache/apk/*
 
 ADD . /dejavu
 
-RUN yarn && yarn cache clean && yarn build:app && rm -rf /dejavu/node_modules && rm -rf /tmp/*
+RUN yarn \
+    && yarn cache clean && yarn build:app \
+    && rm -rf /dejavu/node_modules \
+    && rm -rf /tmp/*
 
 EXPOSE 1358
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -16,6 +16,12 @@ RUN yarn \
     && rm -rf /dejavu/node_modules \
     && rm -rf /tmp/*
 
+RUN addgroup -S -g 201 dejavu && \
+    adduser -S -u 201 -G dejavu dejavu && \
+    chown -R dejavu:dejavu /dejavu
+
+USER dejavu
+
 EXPOSE 1358
 
 CMD node server.js


### PR DESCRIPTION
Docker containers should not be run as root as per Docker best practices https://docs.docker.com/develop/develop-images/dockerfile_best-practices/
Since Dejavu does not require root permissions to run, I added dejavu user to the container to allow container to run with lesser priviledges.

If you are interested, I can also refactor the Dockerfile to use multi-stage builds to lessen the application container footprint.