### PR TITLE
Disable spellcheck, autocorrect and autocapitalize on the "Enter index" field

### DIFF
--- a/packages/browser/src/components/ConnectApp/ConnectApp.js
+++ b/packages/browser/src/components/ConnectApp/ConnectApp.js
@@ -521,6 +521,9 @@ class ConnectApp extends Component<Props, State> {
 									onSelect={this.handleAppNameChange}
 									disabled={isConnected}
 									placeholder="Enter index"
+									spellcheck="false"
+									autocorrect="off"
+									autocapitalize="off"
 								/>
 							</Item>
 


### PR DESCRIPTION
There might be other places in the code where this is an issue, but this was the first one I found:

<img width="467" alt="image" src="https://user-images.githubusercontent.com/2458265/214312257-7f42a384-7d2a-43cf-8657-241bcbca1970.png">